### PR TITLE
Fix loading overlay

### DIFF
--- a/quiz_app/src/App.jsx
+++ b/quiz_app/src/App.jsx
@@ -221,6 +221,7 @@ function App() {
                   userScores={userScores}
                   textContent={textContent}
                   setTextContent={setTextContent}
+                  setAppLoading={setLoading}
                 />
               </ProtectedRoute>
             }

--- a/quiz_app/src/components/Loading.jsx
+++ b/quiz_app/src/components/Loading.jsx
@@ -1,11 +1,10 @@
 import React from "react";
+import { createPortal } from "react-dom";
 
-export const Loading = () => {
-  return (
-    <>
-      <div className="fixed inset-0 bg-gray-400 bg-opacity-40 backdrop-blur-sm flex justify-center items-center z-50">
-        <div className="animate-spin rounded-full h-32 w-32 border-t-4 border-b-4 border-green-500"></div>
-      </div>
-    </>
+export const Loading = () =>
+  createPortal(
+    <div className="fixed inset-0 bg-gray-400 bg-opacity-40 backdrop-blur-sm flex justify-center items-center z-50">
+      <div className="animate-spin rounded-full h-32 w-32 border-t-4 border-b-4 border-green-500"></div>
+    </div>,
+    document.body
   );
-};

--- a/quiz_app/src/pages/FileParser.jsx
+++ b/quiz_app/src/pages/FileParser.jsx
@@ -1,50 +1,53 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { FileUpload } from "../components/FileUpload";
-import { Loading } from "../components/Loading";
 import { parseFile } from "../utils/api";
 import { getTopicsFromText } from "../utils/ai";
 
-export const FileParser = ({ userScores, textContent, setTextContent }) => {
+export const FileParser = ({
+  userScores,
+  textContent,
+  setTextContent,
+  setAppLoading,
+}) => {
   const navigate = useNavigate();
-  const [loading, setLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState(null);
   const [localTextContent, setLocalTextContent] = useState(textContent);
 
   const handleExtractTopics = async () => {
     try {
-      setLoading(true);
+      setAppLoading(true);
       const topics = await getTopicsFromText(
         localTextContent,
         Object.keys(userScores)
       );
-      setLoading(false);
+      setAppLoading(false);
       return topics;
     } catch (error) {
       console.error("Error extracting topics:", error);
-      setLoading(false);
+      setAppLoading(false);
       return [];
     }
   };
 
   const handleFileSelect = async (file) => {
     setSelectedFile(file);
-    setLoading(true);
+    setAppLoading(true);
     if (file) {
       const parsedContent = await parseFile(file);
       setLocalTextContent(parsedContent);
     } else {
       setLocalTextContent("");
     }
-    setLoading(false);
+    setAppLoading(false);
   };
 
   const onGenerateQuiz = async () => {
     try {
-      setLoading(true);
+      setAppLoading(true);
       setTextContent(localTextContent);
       // Extract topics from the text content
-      const topics = await handleExtractTopics(localTextContent);
+      const topics = await handleExtractTopics();
       navigate("/topic-selection", {
         state: {
           extractedTopics: topics || [],
@@ -52,9 +55,9 @@ export const FileParser = ({ userScores, textContent, setTextContent }) => {
           selectedFile: selectedFile,
         },
       });
-      setLoading(false);
+      setAppLoading(false);
     } catch (error) {
-      setLoading(false);
+      setAppLoading(false);
       navigate("/topic-selection", {
         state: {
           extractedTopics: [],
@@ -108,8 +111,6 @@ export const FileParser = ({ userScores, textContent, setTextContent }) => {
         </div>
       </div>
 
-      {/* Loading Overlay */}
-      {loading && <Loading />}
     </>
   );
 };


### PR DESCRIPTION
## Summary
- refine Loading overlay with a React portal
- use global loading state in FileParser for smoother transitions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850a08f088833194c59c70baed62b9